### PR TITLE
Add animated weather dashboard inspired by iOS 18

### DIFF
--- a/weather/index.html
+++ b/weather/index.html
@@ -1,0 +1,1042 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Apple Weather · iOS 18 灵感卡片</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg-gradient: radial-gradient(140% 120% at 0% 0%, #fee0a0 0%, #3d3f75 48%, #070b1d 100%);
+            --accent-color: #FBC85B;
+            --hero-glow: rgba(252, 200, 91, 0.5);
+            font-family: "SF Pro Display", "SF Pro Text", "Helvetica Neue", "PingFang SC", system-ui, -apple-system, sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 3.5rem 2.5rem 4.5rem;
+            color: #f7f9ff;
+            background: var(--bg-gradient);
+            background-size: 180% 180%;
+            animation: gradientShift 22s ease-in-out infinite alternate;
+            position: relative;
+            overflow: hidden;
+        }
+
+        body::before {
+            content: "";
+            position: absolute;
+            inset: -40% -30%;
+            background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.12), transparent 55%),
+                        radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.1), transparent 45%),
+                        radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.14), transparent 65%);
+            filter: blur(0);
+            opacity: 0.7;
+            pointer-events: none;
+            mix-blend-mode: screen;
+            animation: aurora 28s ease-in-out infinite alternate;
+        }
+
+        @keyframes gradientShift {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+
+        @keyframes aurora {
+            0% { transform: translate3d(-2%, -3%, 0) scale(1); opacity: 0.7; }
+            50% { transform: translate3d(3%, 1%, 0) scale(1.05); opacity: 0.85; }
+            100% { transform: translate3d(-1%, 2%, 0) scale(1.02); opacity: 0.7; }
+        }
+
+        .orb {
+            position: absolute;
+            width: 420px;
+            height: 420px;
+            border-radius: 50%;
+            background: radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0));
+            filter: blur(12px);
+            opacity: 0.22;
+            pointer-events: none;
+            mix-blend-mode: screen;
+            animation: float 24s ease-in-out infinite;
+        }
+
+        .orb:nth-of-type(1) { top: -120px; left: -120px; animation-delay: -4s; }
+        .orb:nth-of-type(2) { bottom: -180px; right: -60px; animation-delay: -10s; }
+        .orb:nth-of-type(3) { top: 40%; right: 15%; width: 300px; height: 300px; animation-delay: -16s; }
+
+        @keyframes float {
+            0% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.18; }
+            50% { transform: translate3d(14px, -18px, 0) scale(1.08); opacity: 0.3; }
+            100% { transform: translate3d(-18px, 12px, 0) scale(1.02); opacity: 0.18; }
+        }
+
+        main {
+            width: min(1200px, 100%);
+            display: flex;
+            flex-direction: column;
+            gap: 1.8rem;
+            position: relative;
+            z-index: 1;
+        }
+
+        .ios-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            color: rgba(255, 255, 255, 0.75);
+            font-size: 0.9rem;
+            letter-spacing: 0.06em;
+        }
+
+        .ios-header .indicators {
+            display: flex;
+            gap: 0.45rem;
+            align-items: center;
+        }
+
+        .ios-header .indicator {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.35);
+            position: relative;
+        }
+
+        .ios-header .indicator::after {
+            content: "";
+            position: absolute;
+            inset: 2px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.7);
+        }
+
+        .dashboard {
+            display: grid;
+            grid-template-columns: 1.6fr 1fr;
+            gap: 1.8rem;
+        }
+
+        .hero {
+            position: relative;
+            padding: 2.5rem;
+            border-radius: 32px;
+            background: rgba(255, 255, 255, 0.12);
+            backdrop-filter: blur(28px);
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            overflow: hidden;
+            box-shadow: 0 28px 60px -48px rgba(0, 0, 0, 0.6);
+            isolation: isolate;
+        }
+
+        .hero::before {
+            content: "";
+            position: absolute;
+            inset: -30% -30% auto;
+            height: 420px;
+            background: radial-gradient(circle at top left, var(--hero-glow), rgba(255, 255, 255, 0));
+            opacity: 0.75;
+            filter: blur(0px);
+            z-index: -1;
+            animation: heroGlow 18s ease-in-out infinite;
+        }
+
+        @keyframes heroGlow {
+            0% { transform: translate3d(-10%, -12%, 0) scale(1); opacity: 0.6; }
+            50% { transform: translate3d(4%, 8%, 0) scale(1.1); opacity: 0.85; }
+            100% { transform: translate3d(-8%, -10%, 0) scale(1.02); opacity: 0.6; }
+        }
+
+        .hero-top {
+            display: flex;
+            align-items: flex-end;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .hero-location {
+            font-size: 1rem;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.76);
+        }
+
+        .hero-time {
+            font-size: 0.95rem;
+            color: rgba(255, 255, 255, 0.65);
+        }
+
+        .hero-temp {
+            margin-top: 2.5rem;
+            display: flex;
+            align-items: flex-end;
+            gap: 1.75rem;
+        }
+
+        .hero-temp-value {
+            font-size: clamp(4.4rem, 6vw, 6.3rem);
+            font-weight: 600;
+            letter-spacing: -0.04em;
+            text-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+        }
+
+        .hero-temp-detail {
+            display: flex;
+            flex-direction: column;
+            gap: 0.4rem;
+            color: rgba(255, 255, 255, 0.8);
+        }
+
+        .hero-temp-detail .status {
+            font-size: 1.2rem;
+            font-weight: 500;
+        }
+
+        .hero-temp-detail .range {
+            font-size: 0.95rem;
+            letter-spacing: 0.05em;
+            color: rgba(255, 255, 255, 0.65);
+        }
+
+        .hero-highlight {
+            margin-top: 1.5rem;
+            font-size: 1rem;
+            color: rgba(255, 255, 255, 0.72);
+            line-height: 1.5;
+        }
+
+        .segmented-control {
+            margin-top: 2.2rem;
+            background: rgba(255, 255, 255, 0.14);
+            padding: 0.35rem;
+            border-radius: 16px;
+            display: inline-flex;
+            gap: 0.4rem;
+            position: relative;
+        }
+
+        .segment {
+            position: relative;
+            border: none;
+            background: transparent;
+            color: rgba(255, 255, 255, 0.68);
+            font-size: 0.9rem;
+            padding: 0.55rem 1.1rem;
+            border-radius: 12px;
+            cursor: pointer;
+            transition: color 0.35s ease;
+            font-family: inherit;
+        }
+
+        .segment.active {
+            color: #0f1324;
+            font-weight: 600;
+        }
+
+        .segment-highlight {
+            position: absolute;
+            inset: 4px;
+            width: calc(33.33% - 0.26rem);
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.85);
+            transition: transform 0.4s cubic-bezier(0.23, 1, 0.32, 1), background 0.4s ease;
+            z-index: 0;
+        }
+
+        .segment-group {
+            position: relative;
+            display: inline-flex;
+            gap: 0.4rem;
+        }
+
+        .hero-timeline {
+            margin-top: 2.3rem;
+            display: grid;
+            grid-template-columns: repeat(7, minmax(0, 1fr));
+            gap: 1rem;
+        }
+
+        .timeline-bar {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.7rem;
+            font-size: 0.8rem;
+            color: rgba(255, 255, 255, 0.7);
+            text-align: center;
+        }
+
+        .bar-value {
+            font-weight: 600;
+        }
+
+        .bar-track {
+            width: 12px;
+            height: 78px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.12);
+            overflow: hidden;
+            position: relative;
+        }
+
+        .bar-fill {
+            position: absolute;
+            inset: auto 0 0 0;
+            border-radius: 999px;
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
+            transform: translateY(0%);
+            height: 0;
+            transition: height 0.65s cubic-bezier(0.33, 1, 0.68, 1), background 0.4s ease;
+        }
+
+        .hero-meta {
+            margin-top: 2.2rem;
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 1.2rem;
+            font-size: 0.85rem;
+        }
+
+        .hero-meta li {
+            list-style: none;
+            padding: 1.1rem 1.3rem;
+            border-radius: 18px;
+            background: rgba(255, 255, 255, 0.1);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            backdrop-filter: blur(18px);
+            display: grid;
+            gap: 0.35rem;
+        }
+
+        .hero-meta .label {
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.55);
+        }
+
+        .hero-meta .value {
+            font-size: 1rem;
+            font-weight: 600;
+        }
+
+        .card-collection {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 1.4rem;
+        }
+
+        .weather-card {
+            position: relative;
+            padding: 1.8rem;
+            border-radius: 28px;
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.16);
+            backdrop-filter: blur(18px);
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+            gap: 1.2rem;
+            cursor: pointer;
+            transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+                        border 0.4s ease,
+                        box-shadow 0.6s ease,
+                        background 0.6s ease;
+            overflow: hidden;
+            isolation: isolate;
+        }
+
+        .weather-card::before {
+            content: "";
+            position: absolute;
+            inset: -35% -35% auto;
+            height: 280px;
+            background: radial-gradient(circle at top left, var(--accent-soft, rgba(255, 255, 255, 0.25)), transparent 65%);
+            opacity: 0;
+            transition: opacity 0.6s ease;
+            pointer-events: none;
+            z-index: -1;
+        }
+
+        .weather-card.active::before,
+        .weather-card:hover::before {
+            opacity: 1;
+        }
+
+        .weather-card.active {
+            transform: translateY(-16px) scale(1.02);
+            border-color: rgba(255, 255, 255, 0.32);
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0.05));
+            box-shadow: 0 26px 48px -32px rgba(0, 0, 0, 0.5);
+        }
+
+        .card-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .card-title {
+            display: grid;
+            gap: 0.25rem;
+        }
+
+        .card-title strong {
+            font-size: 1.2rem;
+            letter-spacing: 0.04em;
+        }
+
+        .card-title span {
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.64);
+        }
+
+        .card-temp {
+            font-size: 2.6rem;
+            font-weight: 600;
+        }
+
+        .card-icon {
+            position: relative;
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .icon {
+            position: relative;
+            width: 120px;
+            height: 120px;
+        }
+
+        .icon-sunny .sun-core {
+            position: absolute;
+            inset: 22px;
+            border-radius: 50%;
+            background: radial-gradient(circle at 30% 30%, #fff5d1 0%, #fcd469 55%, #faae40 100%);
+            box-shadow: 0 18px 40px rgba(252, 196, 88, 0.45);
+        }
+
+        .icon-sunny .sun-rays {
+            position: absolute;
+            inset: 0;
+            border-radius: 50%;
+            background: conic-gradient(from 0deg, rgba(255, 200, 80, 0.0) 0deg 20deg, rgba(255, 220, 124, 0.7) 20deg 40deg, rgba(255, 200, 80, 0.0) 40deg 60deg);
+            animation: spin 18s linear infinite;
+            mask: radial-gradient(circle, transparent 52px, #000 53px);
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .icon-windy {
+            display: grid;
+            place-items: center;
+        }
+
+        .icon-windy .wind-line {
+            width: 110px;
+            height: 38px;
+            border-radius: 38px;
+            border: 6px solid rgba(255, 255, 255, 0.65);
+            border-right-color: transparent;
+            border-bottom-color: transparent;
+            position: absolute;
+            animation: windFlow 4.5s ease-in-out infinite;
+        }
+
+        .icon-windy .wind-line:nth-child(2) {
+            width: 92px;
+            height: 32px;
+            top: 38px;
+            animation-delay: -1.2s;
+            opacity: 0.75;
+        }
+
+        .icon-windy .wind-line:nth-child(3) {
+            width: 68px;
+            height: 24px;
+            top: 70px;
+            animation-delay: -2.4s;
+            opacity: 0.55;
+        }
+
+        @keyframes windFlow {
+            0% { transform: rotate(20deg) translateX(-10px); opacity: 0; }
+            40% { opacity: 1; }
+            100% { transform: rotate(20deg) translateX(16px); opacity: 0; }
+        }
+
+        .icon-storm .cloud,
+        .icon-snow .cloud {
+            position: absolute;
+            bottom: 32px;
+            left: 50%;
+            width: 120px;
+            height: 64px;
+            border-radius: 40px;
+            background: rgba(255, 255, 255, 0.85);
+            transform: translateX(-50%);
+            filter: drop-shadow(0 18px 32px rgba(0, 0, 0, 0.25));
+        }
+
+        .icon-storm .cloud::before,
+        .icon-storm .cloud::after,
+        .icon-snow .cloud::before,
+        .icon-snow .cloud::after {
+            content: "";
+            position: absolute;
+            width: 72px;
+            height: 72px;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.9);
+            top: -32px;
+        }
+
+        .icon-storm .cloud::before,
+        .icon-snow .cloud::before { left: 10px; }
+        .icon-storm .cloud::after,
+        .icon-snow .cloud::after { right: 10px; }
+
+        .rain-drop {
+            position: absolute;
+            width: 12px;
+            height: 28px;
+            border-radius: 50% 50% 60% 60%;
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(112, 182, 255, 0.8));
+            bottom: 20px;
+            left: calc(50% - 48px);
+            transform-origin: top;
+            animation: rainFall 1.2s ease-in infinite;
+        }
+
+        .rain-drop:nth-child(2) { left: calc(50% - 16px); animation-delay: -0.3s; }
+        .rain-drop:nth-child(3) { left: calc(50% + 22px); animation-delay: -0.6s; }
+
+        @keyframes rainFall {
+            0% { transform: translateY(-16px) scaleY(0.7); opacity: 0; }
+            40% { opacity: 1; }
+            100% { transform: translateY(28px) scaleY(1.1); opacity: 0; }
+        }
+
+        .lightning {
+            position: absolute;
+            width: 6px;
+            height: 48px;
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0));
+            left: calc(50% + 40px);
+            bottom: 28px;
+            clip-path: polygon(40% 0, 60% 0, 60% 36%, 100% 36%, 40% 100%, 35% 100%, 55% 60%, 0 60%);
+            animation: flash 3.5s ease-in-out infinite;
+            box-shadow: 0 0 20px rgba(255, 255, 255, 0.6);
+        }
+
+        @keyframes flash {
+            0%, 88%, 100% { opacity: 0; }
+            90% { opacity: 1; }
+            92% { opacity: 0.4; }
+        }
+
+        .snowflake {
+            position: absolute;
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            border: 2px solid rgba(255, 255, 255, 0.85);
+            top: 56px;
+            left: calc(50% - 45px);
+            animation: snowDrift 3s ease-in-out infinite;
+        }
+
+        .snowflake::before,
+        .snowflake::after {
+            content: "";
+            position: absolute;
+            inset: -4px;
+            border-radius: 50%;
+            border: 2px solid rgba(255, 255, 255, 0.65);
+            transform: rotate(45deg);
+        }
+
+        .snowflake:nth-child(2) { left: calc(50% - 12px); animation-delay: -1.2s; opacity: 0.85; }
+        .snowflake:nth-child(3) { left: calc(50% + 28px); animation-delay: -2.1s; opacity: 0.65; }
+
+        @keyframes snowDrift {
+            0% { transform: translateY(-8px) rotate(0deg); opacity: 0; }
+            30% { opacity: 1; }
+            100% { transform: translateY(24px) rotate(40deg); opacity: 0; }
+        }
+
+        .card-footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 0.85rem;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .chip {
+            padding: 0.4rem 0.75rem;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.15);
+            border: 1px solid rgba(255, 255, 255, 0.24);
+        }
+
+        @media (max-width: 1100px) {
+            .dashboard {
+                grid-template-columns: 1fr;
+            }
+
+            .hero {
+                order: -1;
+            }
+        }
+
+        @media (max-width: 960px) {
+            body {
+                padding: 3rem 1.5rem 3.5rem;
+            }
+
+            .card-collection {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+
+        @media (max-width: 620px) {
+            main { gap: 1.4rem; }
+            .hero {
+                padding: 2rem;
+            }
+
+            .hero-temp {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 1.25rem;
+            }
+
+            .hero-timeline {
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+                gap: 0.85rem;
+            }
+
+            .hero-meta {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+
+            .card-collection {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="orb"></div>
+    <div class="orb"></div>
+    <div class="orb"></div>
+    <main>
+        <header class="ios-header">
+            <span>Cupertino · Apple Weather</span>
+            <div class="indicators">
+                <span class="indicator"></span>
+                <span class="indicator"></span>
+                <span class="indicator"></span>
+            </div>
+        </header>
+        <section class="dashboard">
+            <article class="hero">
+                <div class="hero-top">
+                    <span class="hero-location" id="heroLocation"></span>
+                    <span class="hero-time" id="heroTime"></span>
+                </div>
+                <div class="hero-temp">
+                    <span class="hero-temp-value" id="heroTemp"></span>
+                    <div class="hero-temp-detail">
+                        <span class="status" id="heroStatus"></span>
+                        <span class="range" id="heroRange"></span>
+                    </div>
+                </div>
+                <p class="hero-highlight" id="heroHighlight"></p>
+                <div class="segmented-control" role="tablist" aria-label="forecast mode">
+                    <div class="segment-highlight" aria-hidden="true"></div>
+                    <div class="segment-group">
+                        <button class="segment active" data-mode="hourly">逐小时</button>
+                        <button class="segment" data-mode="daily">未来 7 天</button>
+                        <button class="segment" data-mode="aqi">空气质量</button>
+                    </div>
+                </div>
+                <div class="hero-timeline" id="heroTimeline"></div>
+                <ul class="hero-meta" id="heroMeta"></ul>
+            </article>
+            <section class="card-collection" id="cardCollection"></section>
+        </section>
+    </main>
+    <script>
+        const forecastData = [
+            {
+                id: "sunny",
+                title: "晴天",
+                subtitle: "阳光充沛 · 天空澄澈",
+                location: "Apple Park · 库比蒂诺",
+                accent: "#FBC85B",
+                accentSoft: "rgba(252, 200, 91, 0.45)",
+                glow: "rgba(252, 200, 91, 0.55)",
+                background: "radial-gradient(140% 120% at 4% 0%, #ffe7a3 0%, #ff9770 38%, #1b1f48 100%)",
+                temperature: { current: 28, high: 31, low: 22 },
+                narrative: {
+                    hourly: "接下来 12 小时以晴朗为主，午后温度攀升至 31°，傍晚风向转为西南，晚间体感舒适。",
+                    daily: "本周保持晴好，昼夜温差在 8° 左右，周五有轻微高云。适合安排户外出行或拍摄。",
+                    aqi: "空气质量指数维持在 32 优，视野清晰，适宜进行任何户外运动。"
+                },
+                meta: [
+                    { label: "风速", value: "西南风 8 km/h" },
+                    { label: "湿度", value: "44%" },
+                    { label: "日出", value: "06:12" }
+                ],
+                timelines: {
+                    hourly: {
+                        values: [27, 28, 29, 30, 31, 29, 26],
+                        labels: ["现在", "+1h", "+3h", "+6h", "+9h", "+12h", "明早"],
+                        unit: "°"
+                    },
+                    daily: {
+                        values: [31, 32, 30, 29, 30, 31, 29],
+                        labels: ["周一", "周二", "周三", "周四", "周五", "周六", "周日"],
+                        unit: "°"
+                    },
+                    aqi: {
+                        values: [28, 30, 34, 32, 29, 31, 33],
+                        labels: ["当前", "+3h", "+6h", "+12h", "+18h", "+24h", "+36h"],
+                        unit: ""
+                    }
+                }
+            },
+            {
+                id: "windy",
+                title: "大风",
+                subtitle: "强劲海风 · 阵风 9 级",
+                location: "旧金山湾区",
+                accent: "#7FD1FF",
+                accentSoft: "rgba(127, 209, 255, 0.45)",
+                glow: "rgba(127, 209, 255, 0.45)",
+                background: "radial-gradient(130% 120% at 96% 0%, #97ddff 0%, #4f8dff 38%, #071125 100%)",
+                temperature: { current: 19, high: 22, low: 15 },
+                narrative: {
+                    hourly: "傍晚西北风增强，阵风最高可达 45 km/h，夜间风向逐渐减弱，注意海面浪高。",
+                    daily: "未来几日风力持续偏强，周三气温略回升，需关注沿海地区的出行安排。",
+                    aqi: "海风带走污染物，AQI 保持在 40 左右，空气通透度极佳。"
+                },
+                meta: [
+                    { label: "阵风", value: "45 km/h" },
+                    { label: "湿度", value: "58%" },
+                    { label: "能见度", value: "18 km" }
+                ],
+                timelines: {
+                    hourly: {
+                        values: [18, 19, 19, 20, 21, 20, 18],
+                        labels: ["现在", "+1h", "+3h", "+6h", "+9h", "+12h", "明早"],
+                        unit: "°"
+                    },
+                    daily: {
+                        values: [22, 21, 20, 19, 20, 21, 22],
+                        labels: ["周一", "周二", "周三", "周四", "周五", "周六", "周日"],
+                        unit: "°"
+                    },
+                    aqi: {
+                        values: [38, 40, 42, 41, 37, 39, 40],
+                        labels: ["当前", "+3h", "+6h", "+12h", "+18h", "+24h", "+36h"],
+                        unit: ""
+                    }
+                }
+            },
+            {
+                id: "storm",
+                title: "暴雨",
+                subtitle: "强对流 · 雷暴黄色预警",
+                location: "深圳 · 前海",
+                accent: "#64A8FF",
+                accentSoft: "rgba(100, 168, 255, 0.45)",
+                glow: "rgba(100, 168, 255, 0.55)",
+                background: "radial-gradient(135% 125% at 50% -10%, #5db8ff 0%, #1d2d53 45%, #040915 100%)",
+                temperature: { current: 24, high: 26, low: 22 },
+                narrative: {
+                    hourly: "未来 3 小时将出现强降水，小时雨强最高 28mm，雷暴活跃，室外请注意避雷。",
+                    daily: "本周以降雨为主，周四短暂放晴，周末仍有大雨出现，注意次生灾害。",
+                    aqi: "持续降雨使 PM2.5 降至 18，空气清新，但湿度偏高可能有轻雾。"
+                },
+                meta: [
+                    { label: "降雨量", value: "26 mm" },
+                    { label: "湿度", value: "96%" },
+                    { label: "体感温度", value: "25°" }
+                ],
+                timelines: {
+                    hourly: {
+                        values: [24, 24, 23, 23, 24, 25, 24],
+                        labels: ["现在", "+1h", "+3h", "+6h", "+9h", "+12h", "明早"],
+                        unit: "°"
+                    },
+                    daily: {
+                        values: [26, 25, 24, 25, 27, 26, 25],
+                        labels: ["周一", "周二", "周三", "周四", "周五", "周六", "周日"],
+                        unit: "°"
+                    },
+                    aqi: {
+                        values: [20, 22, 24, 21, 19, 20, 22],
+                        labels: ["当前", "+3h", "+6h", "+12h", "+18h", "+24h", "+36h"],
+                        unit: ""
+                    }
+                }
+            },
+            {
+                id: "snow",
+                title: "暴雪",
+                subtitle: "寒潮入境 · 道路结冰",
+                location: "札幌 · 北海道",
+                accent: "#CFE2FF",
+                accentSoft: "rgba(210, 224, 255, 0.5)",
+                glow: "rgba(210, 224, 255, 0.65)",
+                background: "radial-gradient(130% 130% at 46% -12%, #e8f4ff 0%, #7aa3f1 35%, #040b1d 100%)",
+                temperature: { current: -8, high: -4, low: -12 },
+                narrative: {
+                    hourly: "雪带将在傍晚最强，短时雪率 9 成，北风夹雪体感低至 -15°，能见度不足 200 米。",
+                    daily: "未来一周持续低温，周三雪势稍缓。请提前安排供暖与清雪设备。",
+                    aqi: "寒潮天气使空气清洁度高，AQI 仅 12，呼吸格外清新。"
+                },
+                meta: [
+                    { label: "风速", value: "北风 32 km/h" },
+                    { label: "湿度", value: "72%" },
+                    { label: "积雪", value: "18 cm" }
+                ],
+                timelines: {
+                    hourly: {
+                        values: [-8, -9, -10, -11, -10, -9, -8],
+                        labels: ["现在", "+1h", "+3h", "+6h", "+9h", "+12h", "明早"],
+                        unit: "°"
+                    },
+                    daily: {
+                        values: [-4, -6, -8, -7, -5, -6, -7],
+                        labels: ["周一", "周二", "周三", "周四", "周五", "周六", "周日"],
+                        unit: "°"
+                    },
+                    aqi: {
+                        values: [14, 12, 13, 15, 17, 16, 18],
+                        labels: ["当前", "+3h", "+6h", "+12h", "+18h", "+24h", "+36h"],
+                        unit: ""
+                    }
+                }
+            }
+        ];
+
+        const heroLocation = document.getElementById("heroLocation");
+        const heroTime = document.getElementById("heroTime");
+        const heroTemp = document.getElementById("heroTemp");
+        const heroStatus = document.getElementById("heroStatus");
+        const heroRange = document.getElementById("heroRange");
+        const heroHighlight = document.getElementById("heroHighlight");
+        const heroTimeline = document.getElementById("heroTimeline");
+        const heroMeta = document.getElementById("heroMeta");
+        const cardCollection = document.getElementById("cardCollection");
+        const segmentButtons = document.querySelectorAll(".segment");
+        const segmentHighlight = document.querySelector(".segment-highlight");
+
+        let activeIndex = 0;
+        let currentMode = "hourly";
+
+        const iconTemplates = {
+            sunny: () => `
+                <div class="icon icon-sunny">
+                    <div class="sun-core"></div>
+                    <div class="sun-rays"></div>
+                </div>
+            `,
+            windy: () => `
+                <div class="icon icon-windy">
+                    <div class="wind-line"></div>
+                    <div class="wind-line"></div>
+                    <div class="wind-line"></div>
+                </div>
+            `,
+            storm: () => `
+                <div class="icon icon-storm">
+                    <div class="cloud"></div>
+                    <div class="rain-drop"></div>
+                    <div class="rain-drop"></div>
+                    <div class="rain-drop"></div>
+                    <div class="lightning"></div>
+                </div>
+            `,
+            snow: () => `
+                <div class="icon icon-snow">
+                    <div class="cloud"></div>
+                    <div class="snowflake"></div>
+                    <div class="snowflake"></div>
+                    <div class="snowflake"></div>
+                </div>
+            `
+        };
+
+        function createCard(item, index) {
+            const card = document.createElement("article");
+            card.className = "weather-card";
+            card.dataset.index = index;
+            card.style.setProperty("--accent", item.accent);
+            card.style.setProperty("--accent-soft", item.accentSoft);
+            card.innerHTML = `
+                <div class="card-header">
+                    <div class="card-title">
+                        <strong>${item.title}</strong>
+                        <span>${item.subtitle}</span>
+                    </div>
+                    <span class="card-temp">${item.temperature.current}°</span>
+                </div>
+                <div class="card-icon">
+                    ${iconTemplates[item.id]()}
+                </div>
+                <div class="card-footer">
+                    <span>${item.location}</span>
+                    <span class="chip">${item.temperature.high}° / ${item.temperature.low}°</span>
+                </div>
+            `;
+
+            card.addEventListener("pointerenter", () => card.classList.add("hover"));
+            card.addEventListener("pointerleave", () => card.classList.remove("hover"));
+            card.addEventListener("click", () => setActiveCard(index));
+            return card;
+        }
+
+        function renderCards() {
+            const fragment = document.createDocumentFragment();
+            forecastData.forEach((item, index) => {
+                const card = createCard(item, index);
+                if (index === activeIndex) {
+                    card.classList.add("active");
+                }
+                fragment.appendChild(card);
+            });
+            cardCollection.appendChild(fragment);
+        }
+
+        function updateHero(data) {
+            heroLocation.textContent = data.location;
+            heroTemp.textContent = `${data.temperature.current}°`;
+            heroStatus.textContent = data.subtitle;
+            heroRange.textContent = `最高 ${data.temperature.high}° · 最低 ${data.temperature.low}°`;
+            updateNarrative(data);
+            renderMeta(data.meta);
+            renderTimeline(data.timelines[currentMode]);
+
+            document.documentElement.style.setProperty("--accent-color", data.accent);
+            document.documentElement.style.setProperty("--bg-gradient", data.background);
+            document.documentElement.style.setProperty("--hero-glow", data.glow);
+        }
+
+        function renderMeta(meta) {
+            heroMeta.innerHTML = "";
+            meta.forEach(item => {
+                const li = document.createElement("li");
+                li.innerHTML = `
+                    <span class="label">${item.label}</span>
+                    <span class="value">${item.value}</span>
+                `;
+                heroMeta.appendChild(li);
+            });
+        }
+
+        function renderTimeline(timeline) {
+            if (!timeline) return;
+            const { values, labels, unit } = timeline;
+            heroTimeline.innerHTML = "";
+            const max = Math.max(...values);
+            const min = Math.min(...values);
+            const range = Math.max(1, max - min);
+
+            values.forEach((value, index) => {
+                const normalized = ((value - min) / range) * 100;
+                const bar = document.createElement("div");
+                bar.className = "timeline-bar";
+                bar.innerHTML = `
+                    <span class="bar-value">${value}${unit}</span>
+                    <div class="bar-track">
+                        <div class="bar-fill"></div>
+                    </div>
+                    <span class="bar-label">${labels[index] ?? ""}</span>
+                `;
+                const fill = bar.querySelector(".bar-fill");
+                fill.style.height = `${normalized}%`;
+                fill.style.background = `linear-gradient(180deg, rgba(255, 255, 255, 0.7) 0%, ${forecastData[activeIndex].accentSoft} 100%)`;
+                heroTimeline.appendChild(bar);
+            });
+        }
+
+        function updateNarrative(data) {
+            const narrative = data.narrative[currentMode] || Object.values(data.narrative)[0];
+            heroHighlight.textContent = narrative;
+        }
+
+        function setActiveCard(index) {
+            if (index === activeIndex) return;
+            const previous = cardCollection.querySelector(`.weather-card.active`);
+            if (previous) previous.classList.remove("active");
+            const next = cardCollection.querySelector(`.weather-card[data-index="${index}"]`);
+            if (next) next.classList.add("active");
+            activeIndex = index;
+            updateHero(forecastData[index]);
+        }
+
+        function updateTime() {
+            const now = new Date();
+            const formatted = now.toLocaleTimeString("zh-CN", {
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: false
+            });
+            heroTime.textContent = formatted;
+        }
+
+        function moveSegmentHighlight() {
+            const modes = ["hourly", "daily", "aqi"];
+            const index = modes.indexOf(currentMode);
+            if (index >= 0) {
+                segmentHighlight.style.transform = `translateX(${index * 100}%)`;
+                segmentHighlight.style.background = index === 0
+                    ? "rgba(255, 255, 255, 0.9)"
+                    : index === 1
+                        ? "rgba(255, 255, 255, 0.82)"
+                        : "rgba(255, 255, 255, 0.78)";
+            }
+        }
+
+        segmentButtons.forEach(button => {
+            button.addEventListener("click", () => {
+                const mode = button.dataset.mode;
+                if (mode === currentMode) return;
+                currentMode = mode;
+                segmentButtons.forEach(b => b.classList.toggle("active", b.dataset.mode === mode));
+                moveSegmentHighlight();
+                updateNarrative(forecastData[activeIndex]);
+                renderTimeline(forecastData[activeIndex].timelines[currentMode]);
+            });
+        });
+
+        function init() {
+            renderCards();
+            updateHero(forecastData[activeIndex]);
+            moveSegmentHighlight();
+            updateTime();
+            setInterval(updateTime, 60000);
+        }
+
+        init();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone weather dashboard page with an aurora-style animated background and glassmorphism containers
- style four horizontal weather cards with custom animated icons representing sunny, windy, stormy, and blizzard conditions
- implement JavaScript to populate card data, update the hero panel, and drive the segmented control timeline transitions

## Testing
- not run (static page)


------
https://chatgpt.com/codex/tasks/task_b_68c9ca93b6bc832eafc17a4124b6ce59